### PR TITLE
Jwscook/backticksjulia

### DIFF
--- a/plugin/judocstring.vim
+++ b/plugin/judocstring.vim
@@ -98,7 +98,7 @@ function! s:generate_docstring_from_map(rmap)
         let rstr = rstr . "...\n\n"
     endif
     let rstr = rstr . "# Example\n"
-    let rstr = rstr . "```julian"
+    let rstr = rstr . "```julia"
     let rstr = rstr . "```\n"
     let rstr = rstr . "\"\"\""
     "echo rstr

--- a/plugin/judocstring.vim
+++ b/plugin/judocstring.vim
@@ -98,7 +98,7 @@ function! s:generate_docstring_from_map(rmap)
         let rstr = rstr . "...\n\n"
     endif
     let rstr = rstr . "# Example\n"
-    let rstr = rstr . "```julia"
+    let rstr = rstr . "```julia\n"
     let rstr = rstr . "```\n"
     let rstr = rstr . "\"\"\""
     "echo rstr

--- a/plugin/judocstring.vim
+++ b/plugin/judocstring.vim
@@ -74,8 +74,8 @@ function! s:generate_docstring_from_map(rmap)
     "    ...
     "
     "   # Example
-    "   '''
-    "   '''
+    "   ```julia
+    "   ```
     "   \"\"\"
     "
 
@@ -98,8 +98,8 @@ function! s:generate_docstring_from_map(rmap)
         let rstr = rstr . "...\n\n"
     endif
     let rstr = rstr . "# Example\n"
-    let rstr = rstr . "'''\n"
-    let rstr = rstr . "'''\n"
+    let rstr = rstr . "```julian"
+    let rstr = rstr . "```\n"
     let rstr = rstr . "\"\"\""
     "echo rstr
     return rstr


### PR DESCRIPTION
Having just used `Documenter.jl` with docstring generated from this tool I found that the Examples work by doing:

> # Example
> triple backtick julia
> triple backtick

(github renders this to markdown which makes it difficult to type, even when quoting), rather than 

> # Example
> triple apostrophe
> triple apostrophe

If you check the diff, you'll see what I mean.
